### PR TITLE
Change cli banner art (#186)

### DIFF
--- a/src/banner.cr
+++ b/src/banner.cr
@@ -1,11 +1,9 @@
 def banner
   content = <<-CONTENT
-              .__
-  ____   ____ |__|______
- /    \\ /  _ \\|  \\_  __ \\
-|   |  (  <♠️> )  ||  | \\/
-|___|  /\\____/|__||__|
-     \\/                 v#{Noir::VERSION}
+░█▄─░█ ░█▀▀▀█ ▀█▀ ░█▀▀█
+░█░█░█ ░█──░█ ░█─ ░█▄▄▀
+░█──▀█ ░█▄▄▄█ ▄█▄ ░█─░█ {v#{Noir::VERSION}}
+
 CONTENT
   STDERR.puts content
   STDERR.puts ""


### PR DESCRIPTION
I'm replacing the CLI banner. Now, the word "NOIR" can be clearly identified compared to the previous version :D

![](https://github.com/noir-cr/noir/assets/13212227/39735362-3b13-47ad-a3fa-6e176838fc9c)

ref: #186