### PR TITLE
Add --include-path flag (#155)

### DIFF
--- a/spec/unit_test/models/endpoint_spec.cr
+++ b/spec/unit_test/models/endpoint_spec.cr
@@ -24,4 +24,41 @@ describe "Initialize 3 arguments" do
   it "detect_params" do
     endpoint.params.should eq([Param.new("a", "b", "query")])
   end
+
+  path = "path/a/b/c"
+  line = 123
+  path_info = PathInfo.new(path, line)
+  endpoint2 = Endpoint.new("/abcd", "GET", Details.new(path_info))
+  it "detect_url" do
+    endpoint2.url.should eq("/abcd")
+  end
+  it "detect_method" do
+    endpoint2.method.should eq("GET")
+  end
+  it "detect_details" do
+    endpoint2.details.should eq(Details.new(path_info))
+    endpoint2.details.code_paths[0].path.should eq(path)
+    endpoint2.details.code_paths[0].line.should eq(line)
+  end
+end
+
+describe "Initialize 4 arguments" do
+  path = "path/a/b/c"
+  line = 123
+  path_info = PathInfo.new(path, line)
+  endpoint = Endpoint.new("/abcd", "GET", [Param.new("a", "b", "query")], Details.new(path_info))
+  it "detect_url" do
+    endpoint.url.should eq("/abcd")
+  end
+  it "detect_method" do
+    endpoint.method.should eq("GET")
+  end
+  it "detect_params" do
+    endpoint.params.should eq([Param.new("a", "b", "query")])
+  end
+  it "detect_details" do
+    endpoint.details.should eq(Details.new(path_info))
+    endpoint.details.code_paths[0].path.should eq(path)
+    endpoint.details.code_paths[0].line.should eq(line)
+  end
 end

--- a/src/analyzer/analyzers/analyzer_armeria.cr
+++ b/src/analyzer/analyzers/analyzer_armeria.cr
@@ -12,6 +12,8 @@ class AnalyzerArmeria < Analyzer
         next if File.directory?(path)
 
         if File.exists?(path) && (path.ends_with?(".java") || path.ends_with?(".kt"))
+          details = Details.new(PathInfo.new(path))
+
           content = File.read(path, encoding: "utf-8", invalid: :skip)
           content.scan(REGEX_SERVER_CODE_BLOCK) do |server_codeblcok_match|
             server_codeblock = server_codeblcok_match[0]
@@ -30,7 +32,7 @@ class AnalyzerArmeria < Analyzer
               endpoint = split_params[endpoint_param_index].strip
 
               endpoint = endpoint[1..-2]
-              @result << Endpoint.new("#{endpoint}", "GET")
+              @result << Endpoint.new("#{endpoint}", "GET", details)
             end
 
             server_codeblock.scan(REGEX_ROUTE_CODE) do |route_code_match|
@@ -47,7 +49,7 @@ class AnalyzerArmeria < Analyzer
               next if endpoint[0] != '"'
 
               endpoint = endpoint[1..-2]
-              @result << Endpoint.new("#{endpoint}", method)
+              @result << Endpoint.new("#{endpoint}", method, details)
             end
           end
         end

--- a/src/analyzer/analyzers/analyzer_crystal_kemal.cr
+++ b/src/analyzer/analyzers/analyzer_crystal_kemal.cr
@@ -9,9 +9,11 @@ class AnalyzerCrystalKemal < Analyzer
         if File.exists?(path) && File.extname(path) == ".cr" && !path.includes?("lib")
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
             last_endpoint = Endpoint.new("", "")
-            file.each_line do |line|
+            file.each_line.with_index do |line, index|
               endpoint = line_to_endpoint(line)
               if endpoint.method != ""
+                details = Details.new(PathInfo.new(path, index + 1))
+                endpoint.set_details(details)
                 result << endpoint
                 last_endpoint = endpoint
               end

--- a/src/analyzer/analyzers/analyzer_crystal_lucky.cr
+++ b/src/analyzer/analyzers/analyzer_crystal_lucky.cr
@@ -21,9 +21,11 @@ class AnalyzerCrystalLucky < Analyzer
         if File.exists?(path) && File.extname(path) == ".cr" && !path.includes?("lib")
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
             last_endpoint = Endpoint.new("", "")
-            file.each_line do |line|
+            file.each_line.with_index do |line, index|
               endpoint = line_to_endpoint(line)
               if endpoint.method != ""
+                details = Details.new(PathInfo.new(path, index + 1))
+                endpoint.set_details(details)
                 result << endpoint
                 last_endpoint = endpoint
               end

--- a/src/analyzer/analyzers/analyzer_cs_aspnet_mvc.cr
+++ b/src/analyzer/analyzers/analyzer_cs_aspnet_mvc.cr
@@ -11,7 +11,7 @@ class AnalyzerCsAspNetMvc < Analyzer
         maproute_check = false
         maproute_buffer = ""
 
-        file.each_line do |line|
+        file.each_line.with_index do |line, index|
           if line.includes? ".MapRoute("
             maproute_check = true
             maproute_buffer = line
@@ -25,7 +25,8 @@ class AnalyzerCsAspNetMvc < Analyzer
               buffer.split(",").each do |item|
                 if item.includes? "url:"
                   url = item.gsub(/url:/, "").gsub(/"/, "")
-                  @result << Endpoint.new("/#{url}", "GET")
+                  details = Details.new(PathInfo.new(route_config_file, index + 1))
+                  @result << Endpoint.new("/#{url}", "GET", details)
                 end
               end
 

--- a/src/analyzer/analyzers/analyzer_elixir_phoenix.cr
+++ b/src/analyzer/analyzers/analyzer_elixir_phoenix.cr
@@ -8,13 +8,14 @@ class AnalyzerElixirPhoenix < Analyzer
         next if File.directory?(path)
         if File.exists?(path) && File.extname(path) == ".ex"
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-            last_endpoint = Endpoint.new("", "")
-            file.each_line do |line|
-              endpoint = line_to_endpoint(line)
-              if endpoint.method != ""
-                @result << endpoint
-                last_endpoint = endpoint
-                _ = last_endpoint
+            file.each_line.with_index do |line, index|
+              endpoints = line_to_endpoint(line)
+              endpoints.each do |endpoint|
+                if endpoint.method != ""
+                  details = Details.new(PathInfo.new(path, index + 1))
+                  endpoint.set_details(details)
+                  @result << endpoint
+                end
               end
             end
           end
@@ -27,34 +28,36 @@ class AnalyzerElixirPhoenix < Analyzer
     @result
   end
 
-  def line_to_endpoint(line : String) : Endpoint
+  def line_to_endpoint(line : String) : Array(Endpoint)
+    endpoints = Array(Endpoint).new
+
     line.scan(/get\s+['"](.+?)['"]\s*,\s*(.+?)\s*/) do |match|
-      @result << Endpoint.new("#{match[1]}", "GET")
+      endpoints << Endpoint.new("#{match[1]}", "GET")
     end
 
     line.scan(/post\s+['"](.+?)['"]\s*,\s*(.+?)\s*/) do |match|
-      @result << Endpoint.new("#{match[1]}", "POST")
+      endpoints << Endpoint.new("#{match[1]}", "POST")
     end
 
     line.scan(/patch\s+['"](.+?)['"]\s*,\s*(.+?)\s*/) do |match|
-      @result << Endpoint.new("#{match[1]}", "PATCH")
+      endpoints << Endpoint.new("#{match[1]}", "PATCH")
     end
 
     line.scan(/put\s+['"](.+?)['"]\s*,\s*(.+?)\s*/) do |match|
-      @result << Endpoint.new("#{match[1]}", "PUT")
+      endpoints << Endpoint.new("#{match[1]}", "PUT")
     end
 
     line.scan(/delete\s+['"](.+?)['"]\s*,\s*(.+?)\s*/) do |match|
-      @result << Endpoint.new("#{match[1]}", "DELETE")
+      endpoints << Endpoint.new("#{match[1]}", "DELETE")
     end
 
     line.scan(/socket\s+['"](.+?)['"]\s*,\s*(.+?)\s*/) do |match|
       tmp = Endpoint.new("#{match[1]}", "GET")
       tmp.set_protocol("ws")
-      @result << tmp
+      endpoints << tmp
     end
 
-    Endpoint.new("", "")
+    endpoints
   end
 end
 

--- a/src/analyzer/analyzers/analyzer_express.cr
+++ b/src/analyzer/analyzers/analyzer_express.cr
@@ -9,9 +9,11 @@ class AnalyzerExpress < Analyzer
         if File.exists?(path)
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
             last_endpoint = Endpoint.new("", "")
-            file.each_line do |line|
+            file.each_line.with_index do |line, index|
               endpoint = line_to_endpoint(line)
               if endpoint.method != ""
+                details = Details.new(PathInfo.new(path, index + 1))
+                endpoint.set_details(details)
                 result << endpoint
                 last_endpoint = endpoint
               end

--- a/src/analyzer/analyzers/analyzer_fastapi.cr
+++ b/src/analyzer/analyzers/analyzer_fastapi.cr
@@ -167,7 +167,8 @@ class AnalyzerFastAPI < AnalyzerPython
                   end
                 end
 
-                result << Endpoint.new(router_class.join(http_route_path), http_method_name, params)
+                details = Details.new(PathInfo.new(path, index + 1))
+                result << Endpoint.new(router_class.join(http_route_path), http_method_name, params, details)
               end
             end
           end

--- a/src/analyzer/analyzers/analyzer_flask.cr
+++ b/src/analyzer/analyzers/analyzer_flask.cr
@@ -30,7 +30,7 @@ class AnalyzerFlask < AnalyzerPython
       Dir.glob("#{base_path}/**/*.py") do |path|
         next if File.directory?(path)
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-          file.each_line do |line|
+          file.each_line.with_index do |line, index|
             # [TODO] We should be cautious about instance replace with other variable
             match = line.match /(#{REGEX_PYTHON_VARIABLE_NAME})\s*=\s*Flask\s*\(/
             if !match.nil?
@@ -77,7 +77,8 @@ class AnalyzerFlask < AnalyzerPython
                     if !route_url.starts_with? "/"
                       route_url = "/#{route_url}"
                     end
-                    result << Endpoint.new(route_url, "GET")
+                    details = Details.new(PathInfo.new(path, index + 1))
+                    result << Endpoint.new(route_url, "GET", details)
                   end
                 end
               end
@@ -123,6 +124,8 @@ class AnalyzerFlask < AnalyzerPython
                 codeblock_lines = codeblock_lines[1..]
 
                 get_endpoints(route_path, extra_params, codeblock_lines, prefix).each do |endpoint|
+                  details = Details.new(PathInfo.new(path, line_index + 1))
+                  endpoint.set_details(details)
                   result << endpoint
                 end
               end

--- a/src/analyzer/analyzers/analyzer_go_echo.cr
+++ b/src/analyzer/analyzers/analyzer_go_echo.cr
@@ -10,11 +10,12 @@ class AnalyzerGoEcho < Analyzer
         if File.exists?(path) && File.extname(path) == ".go"
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
             last_endpoint = Endpoint.new("", "")
-            file.each_line do |line|
+            file.each_line.with_index do |line, index|
+              details = Details.new(PathInfo.new(path, index + 1))
               if line.includes?(".GET(") || line.includes?(".POST(") || line.includes?(".PUT(") || line.includes?(".DELETE(")
                 get_route_path(line).tap do |route_path|
                   if route_path.size > 0
-                    new_endpoint = Endpoint.new("#{route_path}", line.split(".")[1].split("(")[0])
+                    new_endpoint = Endpoint.new("#{route_path}", line.split(".")[1].split("(")[0], details)
                     result << new_endpoint
                     last_endpoint = new_endpoint
                   end
@@ -69,7 +70,8 @@ class AnalyzerGoEcho < Analyzer
             p_dir["static_path"] = p_dir["static_path"][0..-2]
           end
 
-          result << Endpoint.new("#{p_dir["static_path"]}#{path.gsub(full_path, "")}", "GET")
+          details = Details.new(PathInfo.new(path))
+          result << Endpoint.new("#{p_dir["static_path"]}#{path.gsub(full_path, "")}", "GET", details)
         end
       end
     end

--- a/src/analyzer/analyzers/analyzer_go_fiber.cr
+++ b/src/analyzer/analyzers/analyzer_go_fiber.cr
@@ -10,11 +10,12 @@ class AnalyzerGoFiber < Analyzer
         if File.exists?(path) && File.extname(path) == ".go"
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
             last_endpoint = Endpoint.new("", "")
-            file.each_line do |line|
+            file.each_line.with_index do |line, index|
+              details = Details.new(PathInfo.new(path, index + 1))
               if line.includes?(".Get(") || line.includes?(".Post(") || line.includes?(".Put(") || line.includes?(".Delete(")
                 get_route_path(line).tap do |route_path|
                   if route_path.size > 0
-                    new_endpoint = Endpoint.new("#{route_path}", line.split(".")[1].split("(")[0].upcase)
+                    new_endpoint = Endpoint.new("#{route_path}", line.split(".")[1].split("(")[0].upcase, details)
                     if line.includes?("websocket.New(")
                       new_endpoint.set_protocol("ws")
                     end
@@ -80,7 +81,8 @@ class AnalyzerGoFiber < Analyzer
             p_dir["static_path"] = p_dir["static_path"][0..-2]
           end
 
-          result << Endpoint.new("#{p_dir["static_path"]}#{path.gsub(full_path, "")}", "GET")
+          details = Details.new(PathInfo.new(path))
+          result << Endpoint.new("#{p_dir["static_path"]}#{path.gsub(full_path, "")}", "GET", details)
         end
       end
     end

--- a/src/analyzer/analyzers/analyzer_go_gin.cr
+++ b/src/analyzer/analyzers/analyzer_go_gin.cr
@@ -10,11 +10,12 @@ class AnalyzerGoGin < Analyzer
         if File.exists?(path) && File.extname(path) == ".go"
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
             last_endpoint = Endpoint.new("", "")
-            file.each_line do |line|
+            file.each_line.with_index do |line, index|
+              details = Details.new(PathInfo.new(path, index + 1))
               if line.includes?(".GET(") || line.includes?(".POST(") || line.includes?(".PUT(") || line.includes?(".DELETE(")
                 get_route_path(line).tap do |route_path|
                   if route_path.size > 0
-                    new_endpoint = Endpoint.new("#{route_path}", line.split(".")[1].split("(")[0])
+                    new_endpoint = Endpoint.new("#{route_path}", line.split(".")[1].split("(")[0], details)
                     result << new_endpoint
                     last_endpoint = new_endpoint
                   end
@@ -63,7 +64,8 @@ class AnalyzerGoGin < Analyzer
             p_dir["static_path"] = p_dir["static_path"][0..-2]
           end
 
-          result << Endpoint.new("#{p_dir["static_path"]}#{path.gsub(full_path, "")}", "GET")
+          details = Details.new(PathInfo.new(path))
+          result << Endpoint.new("#{p_dir["static_path"]}#{path.gsub(full_path, "")}", "GET", details)
         end
       end
     end

--- a/src/analyzer/analyzers/analyzer_jsp.cr
+++ b/src/analyzer/analyzers/analyzer_jsp.cr
@@ -33,7 +33,8 @@ class AnalyzerJsp < Analyzer
             rescue
               next
             end
-            result << Endpoint.new("/#{relative_path}", "GET", params_query)
+            details = Details.new(PathInfo.new(path))
+            result << Endpoint.new("/#{relative_path}", "GET", params_query, details)
           end
         end
       end

--- a/src/analyzer/analyzers/analyzer_oas2.cr
+++ b/src/analyzer/analyzers/analyzer_oas2.cr
@@ -9,6 +9,7 @@ class AnalyzerOAS2 < Analyzer
     if swagger_jsons.is_a?(Array(String))
       swagger_jsons.each do |swagger_json|
         if File.exists?(swagger_json)
+          details = Details.new(PathInfo.new(swagger_json))
           content = File.read(swagger_json, encoding: "utf-8", invalid: :skip)
           json_obj = JSON.parse(content)
           base_path = ""
@@ -44,9 +45,9 @@ class AnalyzerOAS2 < Analyzer
                       params << param
                     end
                   end
-                  @result << Endpoint.new(base_path + path, method.upcase, params)
+                  @result << Endpoint.new(base_path + path, method.upcase, params, details)
                 else
-                  @result << Endpoint.new(base_path + path, method.upcase)
+                  @result << Endpoint.new(base_path + path, method.upcase, details)
                 end
               rescue e
                 @logger.debug "Exception of #{swagger_json}/paths/path/method"
@@ -67,6 +68,7 @@ class AnalyzerOAS2 < Analyzer
     if swagger_yamls.is_a?(Array(String))
       swagger_yamls.each do |swagger_yaml|
         if File.exists?(swagger_yaml)
+          details = Details.new(PathInfo.new(swagger_yaml))
           content = File.read(swagger_yaml, encoding: "utf-8", invalid: :skip)
           yaml_obj = YAML.parse(content)
           base_path = ""
@@ -102,9 +104,9 @@ class AnalyzerOAS2 < Analyzer
                       params << param
                     end
                   end
-                  @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params)
+                  @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, details)
                 else
-                  @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase)
+                  @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, details)
                 end
               rescue e
                 @logger.debug "Exception of #{swagger_yaml}/paths/path/method"

--- a/src/analyzer/analyzers/analyzer_oas3.cr
+++ b/src/analyzer/analyzers/analyzer_oas3.cr
@@ -26,6 +26,7 @@ class AnalyzerOAS3 < Analyzer
     if oas3_jsons.is_a?(Array(String))
       oas3_jsons.each do |oas3_json|
         if File.exists?(oas3_json)
+          details = Details.new(PathInfo.new(oas3_json))
           content = File.read(oas3_json, encoding: "utf-8", invalid: :skip)
           json_obj = JSON.parse(content)
 
@@ -76,11 +77,11 @@ class AnalyzerOAS3 < Analyzer
                 end
 
                 if params.size > 0
-                  @result << Endpoint.new(base_path + path, method.upcase, params)
+                  @result << Endpoint.new(base_path + path, method.upcase, params, details)
                 elsif params.size > 0
-                  @result << Endpoint.new(base_path + path, method.upcase, params)
+                  @result << Endpoint.new(base_path + path, method.upcase, params, details)
                 else
-                  @result << Endpoint.new(base_path + path, method.upcase)
+                  @result << Endpoint.new(base_path + path, method.upcase, details)
                 end
               rescue e
                 @logger.debug "Exception of #{oas3_json}/paths/endpoint"
@@ -98,6 +99,7 @@ class AnalyzerOAS3 < Analyzer
     if oas3_yamls.is_a?(Array(String))
       oas3_yamls.each do |oas3_yaml|
         if File.exists?(oas3_yaml)
+          details = Details.new(PathInfo.new(oas3_yaml))
           content = File.read(oas3_yaml, encoding: "utf-8", invalid: :skip)
           yaml_obj = YAML.parse(content)
 
@@ -148,11 +150,11 @@ class AnalyzerOAS3 < Analyzer
                 end
 
                 if params.size > 0
-                  @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params)
+                  @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, details)
                 elsif params.size > 0
-                  @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params)
+                  @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, details)
                 else
-                  @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase)
+                  @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, details)
                 end
               end
             rescue e

--- a/src/analyzer/analyzers/analyzer_php_pure.cr
+++ b/src/analyzer/analyzers/analyzer_php_pure.cr
@@ -45,10 +45,12 @@ class AnalyzerPhpPure < Analyzer
             rescue
               next
             end
+
+            details = Details.new(PathInfo.new(path))
             methods.each do |method|
-              result << Endpoint.new("/#{relative_path}", method, params_body)
+              result << Endpoint.new("/#{relative_path}", method, params_body, details)
             end
-            result << Endpoint.new("/#{relative_path}", "GET", params_query)
+            result << Endpoint.new("/#{relative_path}", "GET", params_query, details)
           end
         end
       end

--- a/src/analyzer/analyzers/analyzer_raml.cr
+++ b/src/analyzer/analyzers/analyzer_raml.cr
@@ -8,6 +8,8 @@ class AnalyzerRAML < Analyzer
     if raml_specs.is_a?(Array(String))
       raml_specs.each do |raml_spec|
         if File.exists?(raml_spec)
+          details = Details.new(PathInfo.new(raml_spec))
+
           content = File.read(raml_spec, encoding: "utf-8", invalid: :skip)
           yaml_obj = YAML.parse(content)
           yaml_obj.as_h.each do |path, path_obj|
@@ -45,7 +47,7 @@ class AnalyzerRAML < Analyzer
                   end
                 end
 
-                @result << Endpoint.new(path.to_s, method.to_s.upcase, params)
+                @result << Endpoint.new(path.to_s, method.to_s.upcase, params, details)
               rescue e
                 @logger.debug "Exception of #{raml_spec}/paths/#{path}/#{method}"
                 @logger.debug_sub e

--- a/src/analyzer/analyzers/analyzer_ruby_hanami.cr
+++ b/src/analyzer/analyzers/analyzer_ruby_hanami.cr
@@ -3,11 +3,13 @@ require "../../models/analyzer"
 class AnalyzerRubyHanami < Analyzer
   def analyze
     # Config Analysis
-    if File.exists?("#{@base_path}/config/routes.rb")
-      File.open("#{@base_path}/config/routes.rb", "r", encoding: "utf-8", invalid: :skip) do |file|
+    path = "#{@base_path}/config/routes.rb"
+    if File.exists?(path)
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
         last_endpoint = Endpoint.new("", "")
-        file.each_line do |line|
-          endpoint = line_to_endpoint(line)
+        file.each_line.with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint = line_to_endpoint(line, details)
           if endpoint.method != ""
             @result << endpoint
             last_endpoint = endpoint
@@ -20,46 +22,46 @@ class AnalyzerRubyHanami < Analyzer
     @result
   end
 
-  def line_to_endpoint(content : String) : Endpoint
+  def line_to_endpoint(content : String, details : Details) : Endpoint
     content.scan(/get\s+['"](.+?)['"]/) do |match|
       if match.size > 1
-        return Endpoint.new("#{match[1]}", "GET")
+        return Endpoint.new("#{match[1]}", "GET", details)
       end
     end
 
     content.scan(/post\s+['"](.+?)['"]/) do |match|
       if match.size > 1
-        return Endpoint.new("#{match[1]}", "POST")
+        return Endpoint.new("#{match[1]}", "POST", details)
       end
     end
 
     content.scan(/put\s+['"](.+?)['"]/) do |match|
       if match.size > 1
-        return Endpoint.new("#{match[1]}", "PUT")
+        return Endpoint.new("#{match[1]}", "PUT", details)
       end
     end
 
     content.scan(/delete\s+['"](.+?)['"]/) do |match|
       if match.size > 1
-        return Endpoint.new("#{match[1]}", "DELETE")
+        return Endpoint.new("#{match[1]}", "DELETE", details)
       end
     end
 
     content.scan(/patch\s+['"](.+?)['"]/) do |match|
       if match.size > 1
-        return Endpoint.new("#{match[1]}", "PATCH")
+        return Endpoint.new("#{match[1]}", "PATCH", details)
       end
     end
 
     content.scan(/head\s+['"](.+?)['"]/) do |match|
       if match.size > 1
-        return Endpoint.new("#{match[1]}", "HEAD")
+        return Endpoint.new("#{match[1]}", "HEAD", details)
       end
     end
 
     content.scan(/options\s+['"](.+?)['"]/) do |match|
       if match.size > 1
-        return Endpoint.new("#{match[1]}", "OPTIONS")
+        return Endpoint.new("#{match[1]}", "OPTIONS", details)
       end
     end
 

--- a/src/analyzer/analyzers/analyzer_ruby_sinatra.cr
+++ b/src/analyzer/analyzers/analyzer_ruby_sinatra.cr
@@ -9,9 +9,11 @@ class AnalyzerRubySinatra < Analyzer
         if File.exists?(path)
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
             last_endpoint = Endpoint.new("", "")
-            file.each_line do |line|
+            file.each_line.with_index do |line, index|
               endpoint = line_to_endpoint(line)
               if endpoint.method != ""
+                details = Details.new(PathInfo.new(path, index + 1))
+                endpoint.set_details(details)
                 @result << endpoint
                 last_endpoint = endpoint
               end

--- a/src/analyzer/analyzers/analyzer_rust_axum.cr
+++ b/src/analyzer/analyzers/analyzer_rust_axum.cr
@@ -11,14 +11,15 @@ class AnalyzerRustAxum < Analyzer
 
         if File.exists?(path) && File.extname(path) == ".rs"
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-            file.each_line do |line|
+            file.each_line.with_index do |line, index|
               if line.includes? ".route("
                 match = line.match(pattern)
                 if match
                   begin
                     route_argument = match[1]
                     callback_argument = match[2]
-                    result << Endpoint.new("#{route_argument}", callback_to_method(callback_argument))
+                    details = Details.new(PathInfo.new(path, index + 1))
+                    result << Endpoint.new("#{route_argument}", callback_to_method(callback_argument), details)
                   rescue
                   end
                 end

--- a/src/analyzer/analyzers/analyzer_spring.cr
+++ b/src/analyzer/analyzers/analyzer_spring.cr
@@ -17,7 +17,8 @@ class AnalyzerSpring < Analyzer
 
           # Spring MVC
           has_class_been_imported = false
-          content.each_line do |line|
+          content.each_line.with_index do |line, index|
+            details = Details.new(PathInfo.new(path, index + 1))
             if has_class_been_imported == false && REGEX_CLASS_DEFINITION.match(line)
               has_class_been_imported = true
             end
@@ -40,7 +41,7 @@ class AnalyzerSpring < Analyzer
                   if line.includes? "RequestMethod"
                     define_requestmapping_handlers(["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE"])
                   else
-                    @result << Endpoint.new("#{url}#{mapping_path}", "GET")
+                    @result << Endpoint.new("#{url}#{mapping_path}", "GET", details)
                   end
                 end
               end
@@ -49,31 +50,31 @@ class AnalyzerSpring < Analyzer
             if line.includes? "PostMapping"
               mapping_paths = mapping_to_path(line)
               mapping_paths.each do |mapping_path|
-                @result << Endpoint.new("#{url}#{mapping_path}", "POST")
+                @result << Endpoint.new("#{url}#{mapping_path}", "POST", details)
               end
             end
             if line.includes? "PutMapping"
               mapping_paths = mapping_to_path(line)
               mapping_paths.each do |mapping_path|
-                @result << Endpoint.new("#{url}#{mapping_path}", "PUT")
+                @result << Endpoint.new("#{url}#{mapping_path}", "PUT", details)
               end
             end
             if line.includes? "DeleteMapping"
               mapping_paths = mapping_to_path(line)
               mapping_paths.each do |mapping_path|
-                @result << Endpoint.new("#{url}#{mapping_path}", "DELETE")
+                @result << Endpoint.new("#{url}#{mapping_path}", "DELETE", details)
               end
             end
             if line.includes? "PatchMapping"
               mapping_paths = mapping_to_path(line)
               mapping_paths.each do |mapping_path|
-                @result << Endpoint.new("#{url}#{mapping_path}", "PATCH")
+                @result << Endpoint.new("#{url}#{mapping_path}", "PATCH", details)
               end
             end
             if line.includes? "GetMapping"
               mapping_paths = mapping_to_path(line)
               mapping_paths.each do |mapping_path|
-                @result << Endpoint.new("#{url}#{mapping_path}", "GET")
+                @result << Endpoint.new("#{url}#{mapping_path}", "GET", details)
               end
             end
           end
@@ -85,7 +86,8 @@ class AnalyzerSpring < Analyzer
               next if match.size != 4
               method = match[2]
               endpoint = match[3].gsub(/\n/, "")
-              @result << Endpoint.new("#{url}#{endpoint}", method)
+              details = Details.new(PathInfo.new(path))
+              @result << Endpoint.new("#{url}#{endpoint}", method, details)
             end
           end
         end

--- a/src/analyzer/analyzers/file_analyzers/base64.cr
+++ b/src/analyzer/analyzers/file_analyzers/base64.cr
@@ -7,7 +7,7 @@ FileAnalyzer.add_hook(->(path : String, url : String) : Array(Endpoint) {
 
   begin
     File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-      file.each_line do |line|
+      file.each_line.with_index do |line, index|
         # Check base64 encoded strings
         base64_match = line.match(/([A-Za-z0-9+\/]{20,}={0,2})/)
         if base64_match
@@ -16,7 +16,8 @@ FileAnalyzer.add_hook(->(path : String, url : String) : Array(Endpoint) {
           if url_match
             parsed_url = URI.parse(url_match[1])
             if parsed_url.to_s.includes? url
-              results << Endpoint.new(parsed_url.path, "GET")
+              details = Details.new(PathInfo.new(path, index + 1))
+              results << Endpoint.new(parsed_url.path, "GET", details)
             end
           end
         end

--- a/src/analyzer/analyzers/file_analyzers/string.cr
+++ b/src/analyzer/analyzers/file_analyzers/string.cr
@@ -6,12 +6,13 @@ FileAnalyzer.add_hook(->(path : String, url : String) : Array(Endpoint) {
 
   begin
     File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-      file.each_line do |line|
+      file.each_line.with_index do |line, index|
         url_match = line.match(/(https?:\/\/[^\s"]+)/)
         if url_match
           parsed_url = URI.parse(url_match[1])
           if parsed_url.to_s.includes? url
-            results << Endpoint.new(parsed_url.path, "GET")
+            details = Details.new(PathInfo.new(path, index + 1))
+            results << Endpoint.new(parsed_url.path, "GET", details)
           end
         end
       end

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -4,15 +4,29 @@ require "yaml"
 struct Endpoint
   include JSON::Serializable
   include YAML::Serializable
-  property url, method, params, protocol
+  property url, method, params, protocol, details
 
   def initialize(@url : String, @method : String)
+    @params = [] of Param
+    @details = Details.new
+    @protocol = "http"
+  end
+
+  def initialize(@url : String, @method : String, @details : Details)
     @params = [] of Param
     @protocol = "http"
   end
 
   def initialize(@url : String, @method : String, @params : Array(Param))
+    @details = Details.new
     @protocol = "http"
+  end
+
+  def initialize(@url : String, @method : String, @params : Array(Param), @details : Details)
+    @protocol = "http"
+  end
+
+  def set_details(@details : Details)
   end
 
   def set_protocol(protocol : String)
@@ -45,6 +59,38 @@ struct Param
   # param_type can be "query", "json", "form", "header", "cookie"
 
   def initialize(@name : String, @value : String, @param_type : String)
+  end
+end
+
+struct Details
+  include JSON::Serializable
+  include YAML::Serializable
+  property code_paths : Array(PathInfo) = [] of PathInfo
+
+  # + New details types to be added in the future..
+
+  def initialize
+  end
+
+  def initialize(code_path : PathInfo)
+    @code_paths << code_path
+  end
+
+  def add_path(code_path : PathInfo)
+    @code_paths << code_path
+  end
+end
+
+struct PathInfo
+  include JSON::Serializable
+  include YAML::Serializable
+  property path, line
+
+  def initialize(@path : String)
+    @line = nil
+  end
+
+  def initialize(@path : String, @line : Int32 | Nil)
   end
 end
 

--- a/src/noir.cr
+++ b/src/noir.cr
@@ -24,6 +24,9 @@ OptionParser.parse do |parser|
   parser.on "-f FORMAT", "--format json", "Set output format \n[plain/json/yaml/markdown-table/curl/httpie/oas2/oas3]" { |var| noir_options[:format] = var }
   parser.on "-o PATH", "--output out.txt", "Write result to file" { |var| noir_options[:output] = var }
   parser.on "--set-pvalue VALUE", "Specifies the value of the identified parameter" { |var| noir_options[:set_pvalue] = var }
+  parser.on "--include-path", "Include file path in the plain result" do
+    noir_options[:include_path] = "yes"
+  end
   parser.on "--no-color", "Disable color output" do
     noir_options[:color] = "no"
   end

--- a/src/options.cr
+++ b/src/options.cr
@@ -1,7 +1,7 @@
 def default_options
   noir_options = {
     :base => "", :url => "", :format => "plain",
-    :output => "", :techs => "", :debug => "no", :color => "yes", :concurrency => "100",
+    :output => "", :techs => "", :debug => "no", :color => "yes", :concurrency => "100", :include_path => "no",
     :send_proxy => "", :send_req => "no", :send_with_headers => "", :send_es => "", :use_matchers => "", :use_filters => "",
     :scope => "url,param", :set_pvalue => "", :nolog => "no",
     :exclude_techs => "",

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -31,6 +31,19 @@ class OutputBuilderCommon < OutputBuilder
         r_buffer += "\n  ○ body: #{r_body}"
       end
 
+      if @options[:include_path] == "yes"
+        details = endpoint.details
+        if details.code_paths && details.code_paths.size > 0
+          details.code_paths.each do |code_path|
+            if code_path.line.nil?
+              r_buffer += "\n  ○ file: #{code_path.path}"
+            else
+              r_buffer += "\n  ○ file: #{code_path.path}##{code_path.line}"
+            end
+          end
+        end
+      end
+
       ob_puts r_buffer
     end
   end


### PR DESCRIPTION
Thank you for the feedback provided at https://github.com/noir-cr/noir/issues/192#issuecomment-1868391647

I have incorporated your suggestions and made some adjustments:

1. Renamed the `Path` struct to `PathInfo`.
The [Path](https://crystal-lang.org/api/1.10.1/Path.html) struct had already been declared.

2. Changed the `--include-file-path` flag to `--include-path`.
I considered using --with-path, but it resembled the --with-headers flag and might cause confusion.

3. Replaced the use of the `paths` variable with `code_paths` in the code.
Using `paths` led to code like `paths[0].path`, which seemed a bit awkward. Therefore, I opted for `code_paths` as the variable name instead.

In the process of refactoring, several analyzer files now include the `Details` object for storing path and line number information. However, in a few cases where the line number couldn't be detected, only path information is stored.

I welcome any additional feedback!