### PR TITLE
Update Crystal versions in CI workflow and shard.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          crystal-version: ['1.8.0', '1.9.0', '1.10.0', '1.11.0']
+          crystal-version: ['1.10.0', '1.11.0']
     steps:
       - uses: actions/checkout@v3
       - uses: MeilCli/setup-crystal-action@v4

--- a/shard.yml
+++ b/shard.yml
@@ -13,6 +13,6 @@ dependencies:
   crest:
     github: mamantoha/crest
 
-crystal: 1.8.2
+crystal: ~> 1.10
 
 license: MIT


### PR DESCRIPTION
This pull request updates the Crystal versions in the CI workflow and shard.yml files. Specifically, it changes the Crystal versions to 1.10.0 and 1.11.0. This update ensures that the project is using the latest versions of Crystal and takes advantage of any bug fixes or improvements introduced in these versions.