### PR TITLE
chore: Update options.cr with version and build info print statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,12 @@ FLAGS:
     --config-file ./config.yaml      Specify the path to a configuration file in YAML format
     --concurrency 100                Set concurrency
 
-  OTHERS:
+  DEBUG:
     -d, --debug                      Show debug messages
     -v, --version                    Show version
+    --build-info                     Show version and Build info
+
+  OTHERS:
     -h, --help                       Show help
 ```
 

--- a/src/options.cr
+++ b/src/options.cr
@@ -107,7 +107,8 @@ def run_options_parser
       noir_options[:debug] = "yes"
     end
     parser.on "-v", "--version", "Show version" do
-      puts Noir::VERSION
+      puts "Noir Version: #{Noir::VERSION}"
+      puts "Build Info: #{Crystal::DESCRIPTION}"
       exit
     end
     parser.on "-h", "--help", "Show help" do

--- a/src/options.cr
+++ b/src/options.cr
@@ -102,15 +102,19 @@ def run_options_parser
     parser.on "--config-file ./config.yaml", "Specify the path to a configuration file in YAML format" { |var| noir_options[:config_file] = var }
     parser.on "--concurrency 100", "Set concurrency" { |var| noir_options[:concurrency] = var }
 
-    parser.separator "\n  OTHERS:".colorize(:blue)
+    parser.separator "\n  DEBUG:".colorize(:blue)
     parser.on "-d", "--debug", "Show debug messages" do
       noir_options[:debug] = "yes"
     end
     parser.on "-v", "--version", "Show version" do
-      puts "Noir Version: #{Noir::VERSION}"
-      puts "Build Info: #{Crystal::DESCRIPTION}"
+      puts Noir::VERSION
       exit
     end
+    parser.on "--build-info", "Show version and Build info" do
+      puts Crystal::DESCRIPTION
+      exit
+    end
+    parser.separator "\n  OTHERS:".colorize(:blue)
     parser.on "-h", "--help", "Show help" do
       puts parser
       puts ""


### PR DESCRIPTION
```
./bin/noir --build-info

░█▄─░█ ░█▀▀▀█ ▀█▀ ░█▀▀█
░█░█░█ ░█──░█ ░█─ ░█▄▄▀
░█──▀█ ░█▄▄▄█ ▄█▄ ░█─░█ {v0.15.1}

Crystal 1.12.1 (2024-04-11)

LLVM: 18.1.4
Default target: aarch64-apple-darwin23.4.0
```